### PR TITLE
🐛 (#48): Fix vehicle actors to store more than one armour

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -578,6 +578,48 @@
           "blightProtection": {
             "label": "Blight Protection"
           },
+          "quantity": {
+            "label": "Quantity",
+            "abbr": "Qty."
+          },
+          "weight": {
+            "0": {
+              "25label": "¼",
+              "5label": "½"
+            },
+            "label": "Weight",
+            "abbr": "Wgh.",
+            "tiny": {
+              "label": "0: Tiny"
+            },
+            "veryLight": {
+              "label": "¼: Very Light"
+            },
+            "light": {
+              "label": "½: Light"
+            },
+            "regular": {
+              "label": "1: Regular"
+            },
+            "heavy": {
+              "label": "2: Heavy"
+            },
+            "veryHeavy": {
+              "label": "3: Very Heavy"
+            },
+            "superHeavy": {
+              "label": "4: Super Heavy"
+            },
+            "extreme": {
+              "label": "5: Extreme"
+            },
+            "0label": "Tiny",
+            "1label": "1",
+            "2label": "2",
+            "3label": "3",
+            "4label": "4",
+            "5label": "5"
+          },
           "cost": {
             "label": "Cost"
           },

--- a/module/data/items/item-armor.mjs
+++ b/module/data/items/item-armor.mjs
@@ -3,9 +3,10 @@ import { CORIOLIS_TGD } from "../../config/config.mjs";
 import { DataHelper } from "../../helpers/data.mjs";
 import { createFeatureTagsAndCheckBulky } from "../../helpers/feature.mjs";
 import EmbeddedFeature from "../embedded/embedded-feature.mjs";
-import cgdItemBase from './base-item.mjs';
+import cgdEquipment from "./item-equipment.mjs";
 
-export default class cgdArmor extends cgdItemBase {
+
+export default class cgdArmor extends cgdEquipment {
   static LOCALIZATION_PREFIXES = [
     'CORIOLIS_TGD.Item.base',
     'CORIOLIS_TGD.Item.Armor',

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1016,7 +1016,8 @@ new coriolistgd.applications.cgdRollDialog({actor, requireAttribute: true, canCh
     if (item.type == "kiteUpgrade" || item.type == "shuttleUpgrade" || item.type == "roverUpgrade")
       return super._onDropItem(event, item);
 
-    if (item.type == "armor" && this.actor.items.filter(it => it.type == "armor").length) {
+    // return if actor is not a vehicle
+    if (!["rover", "shuttle"].includes(this.actor.type) && item.type == "armor" && this.actor.items.filter(it => it.type == "armor").length) {
       ui.notifications.error("This actor already has an armor. Remove it before trying to equip another.");
       return;
     }

--- a/templates/item/configuration-parts/armor.hbs
+++ b/templates/item/configuration-parts/armor.hbs
@@ -3,6 +3,9 @@
     classes="cgd-custom"}}
     {{formGroup systemFields.blightProtection value=system.blightProtection type="number"
     classes="cgd-custom"}}
+    {{formGroup systemFields.quantity value=system.quantity classes="cgd-custom" hidden=(not isEmbedded)}}
+    {{formGroup systemFields.weight choices=config.Equipment.weightChoices value=system.weight localize=true
+  valueAttr="value" labelAttr="label" classes="cgd-custom"}}
     {{formGroup systemFields.cost value=system.cost classes="cgd-custom"}}
     {{formGroup systemFields.extras value=system.extras classes="cgd-custom"}}
     {{formGroup systemFields.tech value=system.tech localize=true

--- a/templates/item/configuration-parts/weapon.hbs
+++ b/templates/item/configuration-parts/weapon.hbs
@@ -13,6 +13,7 @@
   {{formGroup systemFields.maxRange value=system.maxRange choices=config.Weapon.attackRangeChoices localize=true
   classes="cgd-custom"}}
   {{/if}}
+  {{formGroup systemFields.quantity value=system.quantity classes="cgd-custom" hidden=(not isEmbedded)}}
   {{formGroup systemFields.weight choices=config.Equipment.weightChoices value=system.weight localize=true
   valueAttr="value" labelAttr="label" classes="cgd-custom"}}
   {{formGroup systemFields.cost value=system.cost classes="cgd-custom"}}


### PR DESCRIPTION
"partial" fix for vehicle actors that couldn't hold more than one amour.
- implements `weight` and `quanity` based on `item-equipment` in `item-amor`.
- inserted fields on respective template parts
- added weight and quanity fields to en.json @ `CORIOLIS_TGD.Item.Armor.FIELDS.quantity` (although it might not be correct)