### PR TITLE
✨ (#49): Fixes weapons not being show in cargo on vehicle-sheets

### DIFF
--- a/module/sheets/actor-vehicle-sheet.mjs
+++ b/module/sheets/actor-vehicle-sheet.mjs
@@ -98,8 +98,10 @@ export class cgdActorVehicleSheet extends cgdActorSheet {
         continue;
       }
       if (i.type === 'vehicleWeapon') {
-        if (i.system.atHand)
+        if (i.system.atHand) {
+          cargo.push(i);
           weapons.push(i);
+        }
         else
           weaponsInventory.push(i);
         continue;


### PR DESCRIPTION
Show normal weapons on cargo for vehicle sheets.
<img width="835" height="745" alt="image" src="https://github.com/user-attachments/assets/edae3b05-ddc4-4df8-83a1-68bd25b09b97" />
