### PR TITLE
Dragging automations to the macro bar.

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -873,6 +873,13 @@ export class cgdActorSheet extends api.HandlebarsApplicationMixin(
    */
   async _onDragStart(event) {
     const target = event.currentTarget;
+    
+    if (target.dataset.type === "Automation") {
+      target.dataset.type = 'Item';
+      target.dataset.itemId = target.dataset.item.split(".").pop();
+      target.dataset.documentClass = "Item";
+    }
+
     if (target.dataset.rollType != "attribute")
 
       return super._onDragStart(event);

--- a/templates/actor/automations.hbs
+++ b/templates/actor/automations.hbs
@@ -3,7 +3,7 @@
       <label>{{category.label}}</label>
       <div class="all">
       {{#each category.automations as |automation id|}}
-        <button data-action="roll" data-roll-type="automation" data-item="{{automation.parent.parent.uuid}}" data-automation-id="{{automation._id}}"><span>{{automation.name}}</span><span>{{automation.parent.parent.name}}</span></button>
+        <button data-action="roll" data-roll-type="automation" data-item="{{automation.parent.parent.uuid}}" data-automation-id="{{automation._id}}" data-type="Automation" class="draggable"><span>{{automation.name}}</span><span>{{automation.parent.parent.name}}</span></button>
       {{/each}}
       </div>
     {{/each}}


### PR DESCRIPTION
This allows for dragging automations to the macro hotbar, disguising them as their base item.

closes #38
