### PR TITLE
Check for attacks before rolling for attack number

### DIFF
--- a/module/sheets/actor-creature-sheet.mjs
+++ b/module/sheets/actor-creature-sheet.mjs
@@ -53,18 +53,22 @@ export class cgdActorCreatureSheet extends cgdActorNpcSheet {
 
   static async _attack(event, target) {
     const attacks = this.actor.items.filter(it => it.type == "creatureAttack");
-    const roll = await new Roll("1d6").roll();
+    if (!(attacks?.length > 0))
+      console.log("The creature does not have any attacks!");
+      return this.actor;
+    const roll = await new Roll(`1d${attacks.length}`).roll();
     let attackNumber = roll.total;
     console.log(attackNumber, this.actor.system.lastAttack);
     if (this.actor.system.lastAttack == attackNumber)
       attackNumber += 1;
-    if (attackNumber == 7)
+    if (attackNumber == attacks.length)
       attackNumber = 1;
     const currentAttack = attacks[attackNumber - 1];
     await currentAttack.automate(event);
     console.log(this.actor, attackNumber, currentAttack.name);
     return this.actor.update({ "system.lastAttack": attackNumber });
   }
+  
   static async _behavior(event, target) {
     const roll = await new Roll("1d6").roll();
     const content = `<p>${this.actor.system.behaviourPattern[roll.total - 1]}</p>`;


### PR DESCRIPTION
Added a check for available attacks before rolling and using the current number independent from the standard six from the base books.

It checks if the creature has any attacks (to avoid further errors) and rolls the number for that number instead of 6.

closes #57