### PR TITLE
This persists the last selected gear / talent on a automation roll.

### DIFF
--- a/module/data/automations/base-automation.mjs
+++ b/module/data/automations/base-automation.mjs
@@ -36,7 +36,9 @@ export default class BaseAutomation extends foundry.abstract.DataModel {
       showAsSelection: new fields.BooleanField({
         initial: true
       }),
-      origin: new fields.StringField()
+      origin: new fields.StringField(),
+      defaultGear: new fields.DocumentUUIDField(),
+      defaultTalent: new fields.DocumentUUIDField()
     };
   }
 
@@ -100,5 +102,12 @@ export default class BaseAutomation extends foundry.abstract.DataModel {
 
   get actor() {
     return this.parent.parent.actor;
+  }
+
+  async getDefaults() {
+    return {
+      gear: fromUuidSync(this.defaultGear),
+      talent: fromUuidSync(this.defaultTalent)
+    }
   }
 }

--- a/module/data/automations/roll-attribute-automation.mjs
+++ b/module/data/automations/roll-attribute-automation.mjs
@@ -19,8 +19,9 @@ export default class RollAttributeAutomation extends BaseAutomation {
   }
 
   async execute(event) {
+    const { gear, talent } = await this.getDefaults();
     const { item, actor } = this.getParents();
-    const roller = new cgdRollDialog({ actor, attribute: this.attribute, item, canChangeAttribute: this.canChangeAttribute, requireAttribute: this.requireAttribute });
+    const roller = new cgdRollDialog({ actor, attribute: this.attribute, item, canChangeAttribute: this.canChangeAttribute, requireAttribute: this.requireAttribute, defaultGear: gear, defaultTalent: talent, usedAutomation: this._id });
     const result = await roller.wait(event);
     return result;
   }


### PR DESCRIPTION
This is a opinionated solution for feature #39 - after selecting the gear/talent for a automation it saves the selection and loads it on the next launch of the automation, updating with each subsequent change.

It has quite a few changes to some core methods, so @Cussa please doublecheck it ;)