### PR TITLE
✨ (#70): Make simple-sheet equipment and weapons draggable

### DIFF
--- a/templates/actor/simple.hbs
+++ b/templates/actor/simple.hbs
@@ -76,7 +76,7 @@
         <label>{{localize "CORIOLIS_TGD.Item.Equipment.FIELDS.quantity.abbr"}}</label>
       </div>
       {{#each equipments as |item id|}}
-      <div class="equipment-item" data-item-id='{{item._id}}' data-document-class='Item'>
+      <div class="equipment-item draggable" data-item-id='{{item._id}}' data-document-class='Item'>
         <div>
           <a class='rollable' data-roll-type='item' data-action='roll'>
             <img src='{{item.img}}' data-tooltip='{{item.name}}' width='46' height='46' />
@@ -149,7 +149,7 @@
       </div>
       <div>
         {{#each weapons as |item id|}}
-        <div class="weapon-item" data-item-id='{{item._id}}' data-document-class='Item'>
+        <div class="weapon-item draggable" data-item-id='{{item._id}}' data-document-class='Item'>
           <div>
             <a class='rollable' data-roll-type='item' data-action='roll'>
               <img src='{{item.img}}' data-tooltip='{{item.name}}' width='46' height='46' />


### PR DESCRIPTION
## Description
(I'm aware the issue has not been accepted yet, apologies if this breaks the contribution guidelines 🙏 )

Add the `draggable` class modifier to the 'simple' sheet (i.e. which NPCs use) equipment and weapons.
This allows the GM to drag these items between sheets (e.g. NPC -> Explorer).

## Closing issues

closes #70 
