### PR TITLE
🐛 (#77): Fix simple sheet scrollable content when resizing

### DIFF
--- a/scss/components/sheets/_simple.scss
+++ b/scss/components/sheets/_simple.scss
@@ -18,6 +18,7 @@
 
   &:not(.minimized, .minimizing, .maximizing) {
     min-width: 400px;
+    max-width: 715px;
   }
 
   div.simple-sheet {

--- a/scss/components/sheets/_simple.scss
+++ b/scss/components/sheets/_simple.scss
@@ -21,8 +21,8 @@
   }
 
   div.simple-sheet {
-    // display: flex;
-    // flex-direction: column;
+    display: flex;
+    flex-direction: column;
     height: 100%;
 
     .rollable {
@@ -36,7 +36,7 @@
 
     .sheet-header {
       flex-direction: column;
-      flex: 1 1 auto;
+      flex: 0 0 auto;
 
       img.profile-img {
         width: 40%;
@@ -47,6 +47,11 @@
         object-fit: contain;
         background: $c-brown;
         padding: 10px;
+        flex: 1;
+      }
+
+      div.header-fields {
+        flex: 0 0 auto;
       }
     }
 
@@ -56,7 +61,7 @@
 
     div.scrollable {
       // background-color: red;
-      height: calc(100% - 260px);
+      height: 100%;
 
       div.simple-attributes {
         @extend .grid, .grid-3col, %simple-box;

--- a/scss/components/sheets/_simple.scss
+++ b/scss/components/sheets/_simple.scss
@@ -42,6 +42,8 @@
       img.profile-img {
         width: 40%;
         height: 40%;
+        max-width: 250px;
+        max-height: 250px;
         margin: 0 auto 10px;
         border: 2px solid $c-gold;
         aspect-ratio: 1 / 1;


### PR DESCRIPTION
# Thanks for contributing!

## Description
Fix simple sheet `.scrollable` resizing properly when the sheet itself is resized.

Changing a couple of small flex-related attributed to make sure that the original content (e.g. header and spacer) stays the same, but making sure that content within the `.scrollable` div is not being cut off.
Confirmed locally that it only impacts simple sheets (no Explorers, Vehicles, Items, etc).

## Closing issues

closes #77 
