### PR TITLE
🐛 (#91): Fix roll dialogue talent selection

### DIFF
--- a/module/applications/dialog/roller.mjs
+++ b/module/applications/dialog/roller.mjs
@@ -519,7 +519,7 @@ export default class cgdRollDialog extends HandlebarsApplicationMixin(Applicatio
   static async add(event, target) {
     const isTalent = target.dataset.type == "talent";
     const types = isTalent ? ["talent"] : ["equipment", "weapon"];
-    const items = this.actor.items.filter(it => types.indexOf(it.type) >= 0 && it.system.carried)
+    const items = this.actor.items.filter(it => types.indexOf(it.type) >= 0 && (it.system.carried || isTalent))
       .sort((a, b) => (a.name.localeCompare(b.name)));
     let btnIndex = 0;
     const buttons = [


### PR DESCRIPTION
## Description
Added a simple check to the items of a popup used for roll dialogues to allow Talents (that do not have the `carried` property) to be selected nonetheless.

## Closing issues

closes #91

