### PR TITLE
🐛 (#95): Fix automation error messages

### DIFF
--- a/module/data/items/item-equipment.mjs
+++ b/module/data/items/item-equipment.mjs
@@ -89,11 +89,11 @@ export default class cgdEquipment extends cgdItemBase {
 
   canRunAutomation() {
     if (!this.carried) {
-      return new foundry.data.validation.DataModelValidationFailure({
-        message: game.i18n.localize("CORIOLIS_TGD.Item.Equipment.FIELDS.carried.automationError")
-      });
+      return new foundry.data.validation.DataModelValidationFailure(
+        game.i18n.localize("CORIOLIS_TGD.Item.Equipment.FIELDS.carried.automationError")
+      );
     }
     return this.maxBonus == 0 || this.bonus > 0 ? undefined :
-      new foundry.data.validation.DataModelValidationFailure({ message: "You can't run automation for equipments that are broken." });
+      new foundry.data.validation.DataModelValidationFailure("You can't run automation for equipments that are broken.");
   }
 }

--- a/module/data/items/item-vehicle-upgrade.mjs
+++ b/module/data/items/item-vehicle-upgrade.mjs
@@ -49,6 +49,6 @@ export default class cgdVehicleUpgrade extends cgdItemBase {
 
   canRunAutomation() {
     return this.maxBonus == 0 || this.bonus > 0 ? undefined :
-      new foundry.data.validation.DataModelValidationFailure({ message: "You can't run automation for equipments that are broken." });
+      new foundry.data.validation.DataModelValidationFailure("You can't run automation for equipments that are broken.");
   }
 }

--- a/module/data/items/item-weapon.mjs
+++ b/module/data/items/item-weapon.mjs
@@ -63,6 +63,6 @@ export default class cgdWeapon extends cgdEquipment {
       return superResult;
 
     return this.parent.actor.type != "explorer" || this.atHand ? undefined :
-      new foundry.data.validation.DataModelValidationFailure({ message: "You can't run automation for weapons that are not at hand" });
+      new foundry.data.validation.DataModelValidationFailure("You can't run automation for weapons that are not at hand");
   }
 }


### PR DESCRIPTION
## Description

Fix automation errors not being displayed properly due to an object being passed to the constructor of `DataModelValidationFailure` instead of a string.

Notice that it'd be possible to keep this behavior but display the correct message by unpacking the result like `canRunAutomation.message.message`. This might be desirable if there's additional information attached to the failure.
However, since this was not the case I've made it so the constructor is called with a string instead of an object.

## Closing issues

closes #95 
